### PR TITLE
[FIX] ITMS-90809 (Deprecated API Usage) message on AppStore Connect

### DIFF
--- a/src/NSWallet/iOS/NSWallet.iOS.csproj
+++ b/src/NSWallet/iOS/NSWallet.iOS.csproj
@@ -61,6 +61,7 @@
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
+    <MtouchExtraArgs>--optimize=experimental-xforms-product-type</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -99,6 +100,7 @@
     <AssemblyName>NSWallet.iOS</AssemblyName>
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchExtraArgs>--optimize=experimental-xforms-product-type</MtouchExtraArgs>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
This removes message from AppStore Connect about deprecated API usage (UIWebView)